### PR TITLE
Send invite to friends when the window is closed.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
-AC_INIT([Sugar],[0.108.0],[],[sugar])
+AC_INIT([Sugar],[0.109.0.0],[],[sugar])
 
 AC_PREREQ([2.59])
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([configure.ac])
 
-SUCROSE_VERSION="0.108.0"
+SUCROSE_VERSION="0.109.0.0"
 AC_SUBST(SUCROSE_VERSION)
 
 AM_INIT_AUTOMAKE([1.9 foreign dist-xz no-dist-gzip])

--- a/extensions/deviceicon/network.py
+++ b/extensions/deviceicon/network.py
@@ -536,7 +536,7 @@ class WirelessDeviceView(ToolButton):
         else:
             state = network.NM_DEVICE_STATE_UNKNOWN
 
-        if self._mode != network.NM_802_11_MODE_ADHOC and \
+        if self._mode != network.NM_802_11_MODE_ADHOC or \
                 network.is_sugar_adhoc_network(self._ssid) is False:
             if state == network.NM_DEVICE_STATE_ACTIVATED:
                 icon_name = '%s-connected' % 'network-wireless'

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -181,7 +181,7 @@ def _start_window_manager():
     settings = Gio.Settings.new('org.gnome.desktop.interface')
     settings.set_string('cursor-theme', 'sugar')
 
-    _metacity_process = subprocess.Popen(['metacity', '--no-force-fullscreen'])
+    _metacity_process = subprocess.Popen(['metacity', '--no-force-fullscreen', '--no-composite'])
 
     screen = Wnck.Screen.get_default()
     screen.connect('window-manager-changed', __window_manager_changed_cb)

--- a/src/jarabe/view/friendlistpopup.py
+++ b/src/jarabe/view/friendlistpopup.py
@@ -53,14 +53,8 @@ class FriendListPopup(PopWindow):
         self.view.show()
         self.show()
 
-        ok_button = ToolButton(icon_name='document-send')
-        self.get_title_box().add_widget(ok_button, False, -1)
-        ok_button.connect('clicked', self.__send_clicked_cb)
-        ok_button.show()
-
-    def __send_clicked_cb(self, button):
+    def do_destroy(self):
         logging.debug('[GSoC]frind-selected')
         model = self.view.get_model()
         selected = model.get_selected()
         self.emit('friend-selected', selected)
-        self.destroy()


### PR DESCRIPTION
I had an issue with the friends popup - it didn't work with the slightly different api in the upstreamed PopWindow module.  However, I refactored it to just emit the latest friends when the window is closed.  I will send a pull request.

I also merged your branch with some newer commits from upstream.  That is why it looks so messy.
