### PR TITLE
Start activities after creating them with add new

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
-AC_INIT([Sugar],[0.109.0.1],[],[sugar])
+AC_INIT([Sugar],[0.109.0.2],[],[sugar])
 
 AC_PREREQ([2.59])
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([configure.ac])
 
-SUCROSE_VERSION="0.109.0.1"
+SUCROSE_VERSION="0.109.0.2"
 AC_SUBST(SUCROSE_VERSION)
 
 AM_INIT_AUTOMAKE([1.9 foreign dist-xz no-dist-gzip])

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,11 @@
-AC_INIT([Sugar],[0.109.0.0],[],[sugar])
+AC_INIT([Sugar],[0.109.0.1],[],[sugar])
 
 AC_PREREQ([2.59])
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([configure.ac])
 
-SUCROSE_VERSION="0.109.0.0"
+SUCROSE_VERSION="0.109.0.1"
 AC_SUBST(SUCROSE_VERSION)
 
 AM_INIT_AUTOMAKE([1.9 foreign dist-xz no-dist-gzip])

--- a/data/org.sugarlabs.gschema.xml
+++ b/data/org.sugarlabs.gschema.xml
@@ -87,6 +87,13 @@
             <summary>Group Label</summary>
             <description>Label associated with age, e.g., '2nd Grade'</description>
         </key>
+        <key name="resume-activity" type="b">
+            <default>true</default>
+            <summary>Resume Activity</summary>
+            <description>If TRUE, Sugar will set default launch of activities in home view to 'resumable' mode. 
+                         If FALSE, Sugar will set default launch of activities in home view to 'start-new' mode.
+            </description>
+        </key>
         <child name="background" schema="org.sugarlabs.user.background" />
     </schema>
     <schema id="org.sugarlabs.user.background" path="/org/sugarlabs/user/background/">

--- a/extensions/cpsection/language/model.py
+++ b/extensions/cpsection/language/model.py
@@ -57,11 +57,6 @@ def read_all_languages():
             if locale_str.endswith('utf8') and len(lang):
                 locales.append((lang, territory, locale_str))
 
-    # FIXME: This is a temporary workaround for locales that are essential to
-    # OLPC, but are not in Glibc yet.
-    locales.append(('Dari', 'Afghanistan', 'fa_AF.utf8'))
-    locales.append(('Guarani', 'Paraguay', 'gn.utf8'))
-
     locales.sort()
     return locales
 

--- a/extensions/deviceicon/frame.py
+++ b/extensions/deviceicon/frame.py
@@ -27,7 +27,9 @@ import jarabe.frame
 _ICON_NAME = 'module-keyboard'
 _HAS_MALIIT = False
 
+import gi
 try:
+    gi.require_version('Maliit', '1.0')
     from gi.repository import Maliit
 except ImportError:
     logging.debug('Frame: can not create OSK icon: Maliit is not installed.')

--- a/src/jarabe/desktop/favoritesview.py
+++ b/src/jarabe/desktop/favoritesview.py
@@ -149,7 +149,8 @@ class FavoritesView(ViewContainer):
         self._last_clicked_icon = None
 
         self._alert = None
-        self._resume_mode = True
+        self._resume_mode = Gio.Settings(
+            'org.sugarlabs.user').get_boolean('resume-activity')
 
         GLib.idle_add(self.__connect_to_bundle_registry_cb)
 
@@ -417,7 +418,8 @@ class ActivityIcon(CanvasIcon):
 
         self._activity_info = activity_info
         self._journal_entries = []
-        self._resume_mode = True
+        self._resume_mode = Gio.Settings(
+            'org.sugarlabs.user').get_boolean('resume-activity')
 
         self.connect_after('activate', self.__button_activate_cb)
 

--- a/src/jarabe/desktop/homebox.py
+++ b/src/jarabe/desktop/homebox.py
@@ -17,6 +17,7 @@ import logging
 
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import Gio
 
 from jarabe.desktop import favoritesview
 from jarabe.desktop.activitieslist import ActivitiesList
@@ -58,7 +59,8 @@ class HomeBox(Gtk.VBox):
 
         self._set_view(self._favorites_views_indicies[0])
         self._query = ''
-        self._resume_mode = True
+        self._resume_mode = Gio.Settings(
+            'org.sugarlabs.user').get_boolean('resume-activity')
 
     def __desktop_view_icons_changed_cb(self, model):
         number_of_views = desktop.get_number_of_views()
@@ -116,7 +118,7 @@ class HomeBox(Gtk.VBox):
             self._list_view.run_activity(entry._icon_selected[0]['bundle_id'],
                                          self._resume_mode)
             entry._icon_selected = []
-            self.set_resume_mode(True)
+            self.set_resume_mode(self._resume_mode)
 
     def __activitylist_clear_clicked_cb(self, widget, toolbar):
         toolbar.clear_query()

--- a/src/jarabe/desktop/homewindow.py
+++ b/src/jarabe/desktop/homewindow.py
@@ -19,6 +19,7 @@ import logging
 from gi.repository import GObject
 from gi.repository import Gtk
 from gi.repository import Gdk
+from gi.repository import Gio
 from gi.repository import GdkX11
 
 from sugar3.graphics import style
@@ -90,6 +91,11 @@ class HomeWindow(Gtk.Window):
         self._home_box.show()
         self._toolbar.show_view_buttons()
 
+        # Loads the Gsettings value for activity 'resume-mode'
+        setting = Gio.Settings('org.sugarlabs.user')
+        self._resume_mode = setting.get_boolean('resume-activity')
+        self._home_box.set_resume_mode(self._resume_mode)
+
         self._group_box = GroupBox(self._toolbar)
         self._mesh_box = MeshBox(self._toolbar)
         self._transition_box = TransitionBox()
@@ -160,7 +166,7 @@ class HomeWindow(Gtk.Window):
 
     def __key_press_event_cb(self, window, event):
         if self.__is_alt(event) and not self._alt_timeout_sid:
-            self._home_box.set_resume_mode(False)
+            self._home_box.set_resume_mode(not self._resume_mode)
             self._alt_timeout_sid = GObject.timeout_add(100,
                                                         self.__alt_timeout_cb)
 
@@ -171,7 +177,7 @@ class HomeWindow(Gtk.Window):
 
     def __key_release_event_cb(self, window, event):
         if self.__is_alt(event) and self._alt_timeout_sid:
-            self._home_box.set_resume_mode(True)
+            self._home_box.set_resume_mode(self._resume_mode)
             GObject.source_remove(self._alt_timeout_sid)
             self._alt_timeout_sid = None
 
@@ -183,7 +189,7 @@ class HomeWindow(Gtk.Window):
         if modmask & Gdk.ModifierType.MOD1_MASK:
             return True
 
-        self._home_box.set_resume_mode(True)
+        self._home_box.set_resume_mode(self._resume_mode)
 
         if self._alt_timeout_sid:
             GObject.source_remove(self._alt_timeout_sid)

--- a/src/jarabe/journal/journalactivity.py
+++ b/src/jarabe/journal/journalactivity.py
@@ -404,10 +404,12 @@ class JournalActivity(JournalWindow):
             chooser.show_all()
 
     def __activity_selected_cb(self, widget, bundle_id, activity_id):
-        initialize_journal_object(title = self._entry_project.props.text,
-                                        bundle_id=bundle_id, 
-                                        activity_id=activity_id,
-                                        project_metadata=self.project_metadata)
+        jobject = initialize_journal_object(
+            title=self._entry_project.props.text,
+            bundle_id=bundle_id,
+            activity_id=activity_id,
+            project_metadata=self.project_metadata)
+        misc.resume(jobject.metadata, alert_window=self)
 
     def __key_press_event_cb(self, widget, event):
         #if not self._main_toolbox.search_entry.has_focus():

--- a/src/jarabe/journal/objectchooser.py
+++ b/src/jarabe/journal/objectchooser.py
@@ -24,6 +24,7 @@ from gi.repository import Wnck
 from sugar3.graphics import style
 from sugar3.graphics.toolbutton import ToolButton
 from sugar3.graphics.objectchooser import FILTER_TYPE_MIME_BY_ACTIVITY
+from sugar3.graphics.popwindow import PopWindow
 
 from jarabe.journal.listview import BaseListView
 from jarabe.journal.listmodel import ListModel
@@ -34,7 +35,7 @@ from jarabe.model import bundleregistry
 from jarabe.journal.iconview import IconView
 
 
-class ObjectChooser(Gtk.Window):
+class ObjectChooser(PopWindow):
 
     __gtype_name__ = 'ObjectChooser'
 
@@ -44,12 +45,7 @@ class ObjectChooser(Gtk.Window):
 
     def __init__(self, parent=None, what_filter='', filter_type=None,
                  show_preview=False):
-        Gtk.Window.__init__(self)
-        self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
-        self.set_decorated(False)
-        self.set_position(Gtk.WindowPosition.CENTER_ALWAYS)
-        self.set_border_width(style.LINE_WIDTH)
-        self.set_has_resize_grip(False)
+        PopWindow.__init__(self, window_xid=parent.get_xid())
 
         self._selected_object_id = None
         self._show_preview = show_preview
@@ -60,20 +56,27 @@ class ObjectChooser(Gtk.Window):
         self.connect('delete-event', self.__delete_event_cb)
         self.connect('key-press-event', self.__key_press_event_cb)
 
-        if parent is None:
-            logging.warning('ObjectChooser: No parent window specified')
-        else:
-            self.connect('realize', self.__realize_cb, parent)
+        vbox = self.get_vbox()
 
-            screen = Wnck.Screen.get_default()
-            screen.connect('window-closed', self.__window_closed_cb, parent)
+        title_box = self.get_title_box()
 
-        vbox = Gtk.VBox()
-        self.add(vbox)
-        vbox.show()
+        volumes_toolbar = VolumesToolbar()
+        tool_item = Gtk.ToolItem()
+        tool_item.set_expand(True)
+        tool_item.add(volumes_toolbar)
+        title_box.insert(tool_item, 0)
+        tool_item.show()
 
-        title_box = TitleBox(what_filter, filter_type)
-        title_box.connect('volume-changed', self.__volume_changed_cb)
+        title = _('Choose an object')
+        if filter_type == FILTER_TYPE_MIME_BY_ACTIVITY:
+            registry = bundleregistry.get_registry()
+            bundle = registry.get_bundle(what_filter)
+            if bundle is not None:
+                title = _('Choose an object to open with %s activity') % \
+                    bundle.get_name()
+        title_box.set_title(title)
+
+        volumes_toolbar.connect('volume-changed', self.__volume_changed_cb)
         title_box.close_button.connect('clicked',
                                        self.__close_button_clicked_cb)
         title_box.set_size_request(-1, style.GRID_CELL_SIZE)
@@ -111,14 +114,6 @@ class ObjectChooser(Gtk.Window):
         self.set_size_request(width, height)
 
         self._toolbar.update_filters('/', what_filter, filter_type)
-
-    def __realize_cb(self, chooser, parent):
-        self.get_window().set_transient_for(parent)
-        # TODO: Should we disconnect the signal here?
-
-    def __window_closed_cb(self, screen, window, parent):
-        if window.get_xid() == parent.get_xid():
-            self.destroy()
 
     def __entry_activated_cb(self, list_view, uid):
         self._selected_object_id = uid
@@ -158,41 +153,6 @@ class ObjectChooser(Gtk.Window):
 
     def __clear_clicked_cb(self, list_view):
         self._toolbar.clear_query()
-
-
-class TitleBox(VolumesToolbar):
-    __gtype_name__ = 'TitleBox'
-
-    def __init__(self, what_filter='', filter_type=None):
-        VolumesToolbar.__init__(self)
-
-        label = Gtk.Label()
-        title = _('Choose an object')
-        if filter_type == FILTER_TYPE_MIME_BY_ACTIVITY:
-            registry = bundleregistry.get_registry()
-            bundle = registry.get_bundle(what_filter)
-            if bundle is not None:
-                title = _('Choose an object to open with %s activity') % \
-                    bundle.get_name()
-
-        label.set_markup('<b>%s</b>' % title)
-        label.set_alignment(0, 0.5)
-        self._add_widget(label, expand=True)
-
-        self.close_button = ToolButton(icon_name='dialog-cancel')
-        self.close_button.set_tooltip(_('Close'))
-        self.insert(self.close_button, -1)
-        self.close_button.show()
-
-    def _add_widget(self, widget, expand=False):
-        tool_item = Gtk.ToolItem()
-        tool_item.set_expand(expand)
-
-        tool_item.add(widget)
-        widget.show()
-
-        self.insert(tool_item, -1)
-        tool_item.show()
 
 
 class ChooserListView(BaseListView):

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -52,6 +52,15 @@ os.environ['SUGAR_VERSION'] = config.version
 from dbus.mainloop.glib import DBusGMainLoop
 DBusGMainLoop(set_as_default=True)
 
+# define the versions of used libraries that are required
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gst', '1.0')
+gi.require_version('Wnck', '3.0')
+gi.require_version('SugarExt', '1.0')
+gi.require_version('GdkX11', '3.0')
+gi.require_version('WebKit', '3.0')
+
 from gi.repository import Gio
 from gi.repository import GLib
 from gi.repository import Gtk

--- a/src/jarabe/main.py
+++ b/src/jarabe/main.py
@@ -393,6 +393,7 @@ def setup_theme():
     settings.set_property('gtk-theme-name', sugar_theme)
     settings.set_property('gtk-icon-theme-name', 'sugar')
     settings.set_property('gtk-cursor-blink-timeout', 3)
+    settings.set_property('gtk-button-images', True)
 
     icons_path = os.path.join(config.data_path, 'icons')
     Gtk.IconTheme.get_default().append_search_path(icons_path)

--- a/src/jarabe/model/keyboard.py
+++ b/src/jarabe/model/keyboard.py
@@ -17,6 +17,8 @@
 
 import logging
 
+import gi
+gi.require_version('Xkl', '1.0')
 from gi.repository import Gio
 from gi.repository import GdkX11
 from gi.repository import Xkl

--- a/src/jarabe/util/downloader.py
+++ b/src/jarabe/util/downloader.py
@@ -19,6 +19,8 @@ import os
 from urlparse import urlparse
 import tempfile
 
+import gi
+gi.require_version('Soup', '2.4')
 from gi.repository import GObject
 from gi.repository import Soup
 from gi.repository import Gio

--- a/src/jarabe/view/viewhelp.py
+++ b/src/jarabe/view/viewhelp.py
@@ -20,6 +20,8 @@ import logging
 import os
 import json
 
+import gi
+gi.require_version('SoupGNOME', '2.4')
 from gi.repository import Gtk
 from gi.repository import GObject
 from gi.repository import Gdk

--- a/src/jarabe/view/viewsource.py
+++ b/src/jarabe/view/viewsource.py
@@ -23,6 +23,8 @@ import sys
 import logging
 from gettext import gettext as _
 
+import gi
+gi.require_version('GtkSource', '3.0')
 from gi.repository import GObject
 from gi.repository import Pango
 from gi.repository import Gtk


### PR DESCRIPTION
```
Start activities after creating them with add new  …
This is an intuitive behaviour from the user's perspective.
```
